### PR TITLE
issue #21 - fixes Impossible to compile issues

### DIFF
--- a/src/Biggy.Core/Biggy.Core.csproj
+++ b/src/Biggy.Core/Biggy.Core.csproj
@@ -30,11 +30,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Inflector">
-      <HintPath>..\..\..\FluxBot\packages\Inflector.1.0.0.0\lib\net40\Inflector.dll</HintPath>
+      <HintPath>..\..\packages\Inflector.1.0.0.0\lib\net40\Inflector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\FluxBot\packages\Newtonsoft.Json.6.0.7\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.7\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -44,7 +44,7 @@
     <Reference Include="Mono.Data.Sqlite" />
     <Reference Include="System.Xml" />
     <Reference Include="Mono.Security">
-      <HintPath>..\packages\Npgsql.2.2.2\lib\net40\Mono.Security.dll</HintPath>
+      <HintPath>..\..\packages\Npgsql.2.2.2\lib\net40\Mono.Security.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Biggy.Data.Json/Biggy.Data.Json.csproj
+++ b/src/Biggy.Data.Json/Biggy.Data.Json.csproj
@@ -34,11 +34,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Inflector">
-      <HintPath>..\..\..\FluxBot\packages\Inflector.1.0.0.0\lib\net40\Inflector.dll</HintPath>
+      <HintPath>..\..\packages\Inflector.1.0.0.0\lib\net40\Inflector.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\FluxBot\packages\Newtonsoft.Json.6.0.7\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.7\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
this fixes the weird reference paths inside the biggy.core and biggy.data.json packages so that they point to the right nuget references location