### PR TITLE
closed the output stream so that the file handle gets let go sooner

### DIFF
--- a/src/Biggy.Data.Json/JsonStore.cs
+++ b/src/Biggy.Data.Json/JsonStore.cs
@@ -507,6 +507,7 @@ namespace Biggy.Data.Json
                         var writer = new JsonTextWriter(outstream);
                         var serializer = JsonSerializer.CreateDefault();
                         serializer.Serialize(writer, _items);
+                        outstream.Close();
                         completed = true;
                     }
                 }


### PR DESCRIPTION
I noticed that in our production environment that sometimes this would go through its 20 retries and bomb out really quickly. If I closed the output stream at the end, it got much happier!